### PR TITLE
Fix volume binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,33 @@ services:
       - .env
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - prometheus_data:/app/prometheus
+      - nephelios_data:/app/config/prometheus
+      - registry_data:/var/lib/nephelios/registry
+      - grafana_data:/var/lib/nephelios/grafana
+      - grafana_provisioning:/app/config/grafana
+      - grafana_dashboard:/app/config/dashboards
     ports:
       - "3030:3030"
+
+volumes:
+  grafana_data:
+    name: grafana_data
+
+  grafana_provisioning:
+    name: grafana_provisioning
+
+  grafana_dashboard:
+    name: grafana_dashboard
+
+  letsencrypt:
+    name: letsencrypt
+
+  prometheus_data:
+    name: prometheus_data
+
+  registry_data:
+    name: registry_data
+
+  nephelios_data:
+    name: nephelios_data

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,6 @@ use warp::Filter;
 mod metrics;
 use crate::metrics::{CONTAINER_CPU, CONTAINER_MEM, CONTAINER_NET_IN, CONTAINER_NET_OUT, REGISTRY};
 
-use self::services::helpers::docker_helper::ensure_volumes;
-
 /// Entry point for the application.
 ///
 /// Initializes and starts the Warp server. The server listens on `127.0.0.1:3030`
@@ -89,13 +87,6 @@ async fn main() {
     match res_prune_images {
         Ok(_) => println!("✅ Docker images pruned successfully"),
         Err(e) => eprintln!("❌ Failed to prune Docker images: {}", e),
-    }
-
-    println!("🚀 Ensuring Docker volumes exist...");
-    let res_ensure_volumes = ensure_volumes().await;
-    match res_ensure_volumes {
-        Ok(_) => println!("✅ Docker volumes ensured successfully"),
-        Err(e) => eprintln!("❌ Failed to ensure Docker volumes: {}", e),
     }
 
     println!("🚀 Check if Docker Swarm is initialized...");


### PR DESCRIPTION
This pull request involves significant changes to the Docker volume management and related code cleanup. The main changes include the addition of volume definitions in the `docker-compose.yml` file and the removal of the `ensure_volumes` function and its related code from the Rust application.

### Docker volume management:

* Added volume definitions for `prometheus_data`, `nephelios_data`, `registry_data`, `grafana_data`, `grafana_provisioning`, and `grafana_dashboard` in the `docker-compose.yml` file.

### Code cleanup:

* Removed the `ensure_volumes` function and its invocation in `src/main.rs`. This includes the removal of the call to `ensure_volumes` in the `main` function and the corresponding import statement. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL21-L22) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL94-L100)
* Deleted the `ensure_volumes` function and the `NepheliosVolume` struct from `src/services/helpers/docker_helper.rs`. [[1]](diffhunk://#diff-88a8eae44d15c8e0a61b075e21f5252cfabc1ba63d74c4dfc3a91d103cc642e3L986-L1071) [[2]](diffhunk://#diff-88a8eae44d15c8e0a61b075e21f5252cfabc1ba63d74c4dfc3a91d103cc642e3L1254-L1260)