### PR TITLE
Fix Nephelios front port

### DIFF
--- a/nephelios.yml
+++ b/nephelios.yml
@@ -125,20 +125,8 @@ services:
     networks:
       - nephelios_overlay
     ports:
-      - "5173:5173"
+      - "4173:4173"
     deploy:
-      labels:
-          - "traefik.enable=true"
-          - "traefik.http.routers.nephelios.rule=Host(`nephelios.localhost`)"
-          - "traefik.http.routers.nephelios.entrypoints=web,websecure"
-          - "traefik.http.routers.nephelios.tls.certresolver=myresolver"
-          - "traefik.http.services.nephelios.loadbalancer.server.port=4173"
-          - "com.myapp.name=nephelios"
-          - "com.myapp.image=zuhowks/nephelios-front:latest"
-          - "com.myapp.type=nodejs"
-          - "com.myapp.github_url=https://github.com/nephelios/nephelios-front"
-          - "com.myapp.domain=nephelios.localhost"
-          - "com.myapp.created_at={{ Utc::now().to_rfc3339() }}"
       restart_policy:
         condition: on-failure
         delay: 5s

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ async fn main() {
 
     println!("🚀 Server running on http://{}:{}", ip_addr, app_port);
 
-    println!("🚀 Front running on http://localhost:5173");
+    println!("🚀 Front running on http://{}:4173", ip_addr);
 
     // Créer un canal pour la notification de shutdown
     let (shutdown_tx, mut shutdown_rx) = broadcast::channel(1);


### PR DESCRIPTION
This pull request includes several changes to the Docker configuration and Rust codebase for the Nephelios project. The most important changes involve adding new Docker volumes, updating port configurations, and removing unused code related to Docker volume management.

### Docker Configuration Updates:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R12-R41): Added new volumes for Prometheus, Nephelios, and Grafana to the services section and defined these volumes at the end of the file.
* [`nephelios.yml`](diffhunk://#diff-cac2f0d1fe9db11972df9f40296f0733d6b2a3162a9a9d42b0496c449bc50039L128-L141): Changed the port mapping for Nephelios service from `5173:5173` to `4173:4173` and removed Traefik labels from the deploy section.

### Rust Codebase Simplification:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL94-L100): Removed the `ensure_volumes` function call and its associated print statements from the `main` function.
* [`src/services/helpers/docker_helper.rs`](diffhunk://#diff-88a8eae44d15c8e0a61b075e21f5252cfabc1ba63d74c4dfc3a91d103cc642e3L986-L1071): Deleted the `ensure_volumes` function and the `NepheliosVolume` struct, which were used to ensure Docker volumes existed. [[1]](diffhunk://#diff-88a8eae44d15c8e0a61b075e21f5252cfabc1ba63d74c4dfc3a91d103cc642e3L986-L1071) [[2]](diffhunk://#diff-88a8eae44d15c8e0a61b075e21f5252cfabc1ba63d74c4dfc3a91d103cc642e3L1254-L1260)
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL145-R136): Updated the front-end URL print statement to use the new port `4173`.