### PR TITLE
Add expose port 3030

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,6 @@ COPY nephelios.yml /app/nephelios.yml
 
 WORKDIR /app
 
+EXPOSE 3030
+
 CMD ["/usr/local/bin/nephelios"]


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change exposes port 3030, which is likely necessary for the application to communicate over that port.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R52-R53): Added `EXPOSE 3030` to allow network connections on port 3030.